### PR TITLE
Added Pls Work function minigames

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,7 @@ features:
     dig: true
     work: true
   custom_commands:
+  - value: "pls work mod"
   auto_buy:
     fishing_pole: true
     hunting_rifle: true

--- a/config.yml
+++ b/config.yml
@@ -391,6 +391,13 @@ compatibility:
   dig_cancel:
     - "LOL idk this"
     - "No hable english"
+  allowed_ftb:
+    - "I am a dwarf and I diggy the hole"
+    - "Digging is my passion"
+    - "I hope I find some treasure"
+    - "I have never dug up a body"
+    - "I will dig all day and all night"
+    - "Never have I ever dug up a body"
   cooldown:
     beg: 48
     search: 38

--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,7 @@ features:
     fish: true
     hunt: true
     dig: true
+    work: true
   custom_commands:
   auto_buy:
     fishing_pole: true
@@ -398,6 +399,30 @@ compatibility:
     - "I have never dug up a body"
     - "I will dig all day and all night"
     - "Never have I ever dug up a body"
+  allowed_scrambles_work:
+    - "carl-bot"
+    - "moderator"
+    - "permission"
+    - "audit"
+    - "slowmode"
+    - "discord"
+    - "admin"
+    - "hammer"
+    - "welcome"
+    - "softban"
+    - "links"
+    - "advertising"
+    - "support"
+  work_cancel:
+    - "I'm feeling lazy to work today"
+  allowed_hangman:
+    - "Please reread the rules"
+    - "The rules are pretty simple"
+    - "Give that user a mute"
+    - "If you dont like the rules, leave the server"
+    - "Nagging is bad for your health"
+    - "You don't choose the slowmode, the slowmode chooses you"
+    - "This isn't the place to practice abc's"
   cooldown:
     beg: 48
     search: 38
@@ -410,6 +435,7 @@ compatibility:
     gift: 26
     share: 13
     dig: 42
+    work: 10805
   await_response_timeout: 7
 
 suspicion_avoidance:

--- a/config.yml
+++ b/config.yml
@@ -415,6 +415,9 @@ compatibility:
     - "support"
   work_cancel:
     - "I'm feeling lazy to work today"
+    - "Working is for nabs"
+    - "Why play dank when I gotta work here too"
+    - "Why always so hard"
   allowed_hangman:
     - "Please reread the rules"
     - "The rules are pretty simple"

--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,7 @@ features:
     highlow: true
     fish: true
     hunt: true
+    dig: true
   custom_commands:
   auto_buy:
     fishing_pole: true
@@ -373,6 +374,21 @@ compatibility:
     - "i don't want to die"
     - "stop"
     - "."
+  allowed_scrambles:
+    - "scoop"
+    - "dirty"
+    - "ground"
+    - "burrow"
+    - "spider"
+    - "shovel"
+    - "trowel"
+    - "unearth"
+    - "uncover"
+    - "ladybug"
+    - "excavate"
+    - "stickbug"
+  dig_cancel:
+    - "LOL idk this"
   cooldown:
     beg: 48
     search: 38
@@ -384,6 +400,7 @@ compatibility:
     sell: 6
     gift: 26
     share: 13
+    dig: 42
   await_response_timeout: 7
 
 suspicion_avoidance:

--- a/config.yml
+++ b/config.yml
@@ -47,6 +47,7 @@ features:
     fishing_pole: true
     hunting_rifle: true
     laptop: true
+    shovel: true
   auto_sell:
     enable: false
     items:
@@ -389,6 +390,7 @@ compatibility:
     - "stickbug"
   dig_cancel:
     - "LOL idk this"
+    - "No hable english"
   cooldown:
     beg: 48
     search: 38

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type Compat struct {
 	AwaitResponseTimeout int      `yaml:"await_response_timeout"`
 	AllowedScrambles     []string `yaml:"allowed_scrambles"`
 	DigCancel            []string `yaml:"dig_cancel"`
+	AllowedFTB           []string `yaml:"allowed_ftb"`
 }
 
 type Cooldown struct {

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,8 @@ type Compat struct {
 	SearchCancel         []string `yaml:"search_cancel"`
 	Cooldown             Cooldown `yaml:"cooldown"`
 	AwaitResponseTimeout int      `yaml:"await_response_timeout"`
+	AllowedScrambles     []string `yaml:"allowed_scrambles"`
+	DigCancel            []string `yaml:"dig_cancel"`
 }
 
 type Cooldown struct {
@@ -73,6 +75,7 @@ type Cooldown struct {
 	Sell      int `yaml:"sell"`
 	Gift      int `yaml:"gift"`
 	Share     int `yaml:"share"`
+	Dig       int `yaml:"dig"`
 }
 
 type Features struct {
@@ -148,6 +151,7 @@ type Commands struct {
 	Highlow  bool `yaml:"highlow"`
 	Fish     bool `yaml:"fish"`
 	Hunt     bool `yaml:"hunt"`
+	Dig      bool `yaml:"dig"`
 }
 
 type SuspicionAvoidance struct {

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ type Compat struct {
 	AllowedScrambles     []string `yaml:"allowed_scrambles"`
 	DigCancel            []string `yaml:"dig_cancel"`
 	AllowedFTB           []string `yaml:"allowed_ftb"`
+	WorkCancel           []string `yaml:"work_cancel"`
+	AllowedScramblesWork []string `yaml:"allowed_scrambles_work"`
+	AllowedHangman       []string `yaml:"allowed_hangman"`
 }
 
 type Cooldown struct {
@@ -77,6 +80,7 @@ type Cooldown struct {
 	Gift      int `yaml:"gift"`
 	Share     int `yaml:"share"`
 	Dig       int `yaml:"dig"`
+	Work      int `yaml:"work"`
 }
 
 type Features struct {
@@ -154,6 +158,7 @@ type Commands struct {
 	Fish     bool `yaml:"fish"`
 	Hunt     bool `yaml:"hunt"`
 	Dig      bool `yaml:"dig"`
+	Work     bool `yaml:"work"`
 }
 
 type SuspicionAvoidance struct {

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,7 @@ type AutoBuy struct {
 	FishingPole  bool `yaml:"fishing_pole"`
 	HuntingRifle bool `yaml:"hunting_rifle"`
 	Laptop       bool `yaml:"laptop"`
+	Shovel       bool `yaml:"shovel"`
 }
 
 type AutoSell struct {

--- a/config/validate.go
+++ b/config/validate.go
@@ -146,6 +146,15 @@ func validateCompat(compat Compat) error {
 	if len(compat.AllowedSearches) == 0 {
 		return fmt.Errorf("no allowed searches")
 	}
+	if len(compat.AllowedScrambles) == 0 {
+		return fmt.Errorf("no allowed scrambles")
+	}
+	if len(compat.DigCancel) == 0 {
+		return fmt.Errorf("no dig cancel compatibility options")
+	}
+	if compat.Cooldown.Dig <= 0 {
+		return fmt.Errorf("dig cooldown must be greater than 0")
+	}
 	if len(compat.SearchCancel) == 0 {
 		return fmt.Errorf("no search cancel compatibility options")
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -149,6 +149,9 @@ func validateCompat(compat Compat) error {
 	if len(compat.AllowedScrambles) == 0 {
 		return fmt.Errorf("no allowed scrambles")
 	}
+	if len(compat.AllowedScramblesWork) == 0 {
+		return fmt.Errorf("no allowed work scrambles")
+	}
 	if len(compat.AllowedFTB) == 0 {
 		return fmt.Errorf("no allowed dig fill the blanks")
 	}
@@ -158,8 +161,17 @@ func validateCompat(compat Compat) error {
 	if len(compat.SearchCancel) == 0 {
 		return fmt.Errorf("no search cancel compatibility options")
 	}
+	if len(compat.WorkCancel) == 0 {
+		return fmt.Errorf("no work cancel compatibility options")
+	}
+	if len(compat.AllowedHangman) == 0 {
+		return fmt.Errorf("no work hangman options")
+	}
 	if compat.Cooldown.Dig <= 0 {
 		return fmt.Errorf("dig cooldown must be greater than 0")
+	}
+	if compat.Cooldown.Work <= 0 {
+		return fmt.Errorf("work cooldown must be greater than 0")
 	}
 	if compat.Cooldown.Postmeme <= 0 {
 		return fmt.Errorf("postmeme cooldown must be greater than 0")

--- a/config/validate.go
+++ b/config/validate.go
@@ -149,6 +149,9 @@ func validateCompat(compat Compat) error {
 	if len(compat.AllowedScrambles) == 0 {
 		return fmt.Errorf("no allowed scrambles")
 	}
+	if len(compat.AllowedFTB) == 0 {
+		return fmt.Errorf("no allowed dig fill the blanks")
+	}
 	if len(compat.DigCancel) == 0 {
 		return fmt.Errorf("no dig cancel compatibility options")
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -152,11 +152,11 @@ func validateCompat(compat Compat) error {
 	if len(compat.DigCancel) == 0 {
 		return fmt.Errorf("no dig cancel compatibility options")
 	}
-	if compat.Cooldown.Dig <= 0 {
-		return fmt.Errorf("dig cooldown must be greater than 0")
-	}
 	if len(compat.SearchCancel) == 0 {
 		return fmt.Errorf("no search cancel compatibility options")
+	}
+	if compat.Cooldown.Dig <= 0 {
+		return fmt.Errorf("dig cooldown must be greater than 0")
 	}
 	if compat.Cooldown.Postmeme <= 0 {
 		return fmt.Errorf("postmeme cooldown must be greater than 0")

--- a/instance/autobuy.go
+++ b/instance/autobuy.go
@@ -22,6 +22,17 @@ func (in *Instance) abLaptop(_ discord.Message) {
 	})
 }
 
+func (in *Instance) abShovel(_ discord.Message) {
+	trigger := in.sdlr.AwaitResumeTrigger()
+	if trigger == nil || trigger.Value != digCmdValue {
+		return
+	}
+	in.sdlr.ResumeWithCommand(&scheduler.Command{
+		Value: buyCmdValue("1", "shovel"),
+		Log:   "no shovel, buying a new one",
+	})
+}
+
 func (in *Instance) abHuntingRifle(_ discord.Message) {
 	trigger := in.sdlr.AwaitResumeTrigger()
 	if trigger == nil || trigger.Value != huntCmdValue {

--- a/instance/commands.go
+++ b/instance/commands.go
@@ -30,6 +30,7 @@ const (
 	shopBaseCmdValue      = "pls shop"
 	giftBaseCmdValue      = "pls gift"
 	shareBaseCmdValue     = "pls share"
+	digCmdValue           = "pls dig"
 )
 
 func blackjackCmdValue(amount string) string {
@@ -111,6 +112,13 @@ func (in *Instance) newCmds() []*scheduler.Command {
 		cmds = append(cmds, &scheduler.Command{
 			Value:       tidepodCmdValue,
 			Interval:    time.Duration(in.Features.AutoTidepod.Interval) * time.Second,
+			AwaitResume: true,
+		})
+	}
+	if in.Features.Commands.Dig {
+		cmds = append(cmds, &scheduler.Command{
+			Value:       digCmdValue,
+			Interval:    time.Duration(in.Compat.Cooldown.Dig) * time.Second,
 			AwaitResume: true,
 		})
 	}

--- a/instance/commands.go
+++ b/instance/commands.go
@@ -31,6 +31,7 @@ const (
 	giftBaseCmdValue      = "pls gift"
 	shareBaseCmdValue     = "pls share"
 	digCmdValue           = "pls dig"
+	workCmdValue          = "pls work"
 )
 
 func blackjackCmdValue(amount string) string {
@@ -124,6 +125,13 @@ func (in *Instance) newCmds() []*scheduler.Command {
 	}
 	if in.Features.AutoBlackjack.Enable {
 		cmds = append(cmds, in.newAutoBlackjackCmd())
+	}
+	if in.Features.Commands.Work {
+		cmds = append(cmds, &scheduler.Command{
+			Value:       workCmdValue,
+			Interval:    time.Duration(in.Compat.Cooldown.Work) * time.Second,
+			AwaitResume: true,
+		})
 	}
 
 	for _, cmd := range in.Features.CustomCommands {

--- a/instance/dig.go
+++ b/instance/dig.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2021 The Dank Grinder authors.
+//
+// This source code has been released under the GNU Affero General Public
+// License v3.0. A copy of this license is available at
+// https://www.gnu.org/licenses/agpl-3.0.en.html
+//
+// Dig Functionality added by https://github.com/V4NSH4J
+
+package instance
+
+import (
+	"math/rand"
+
+	"github.com/dankgrinder/dankgrinder/discord"
+	"github.com/dankgrinder/dankgrinder/instance/scheduler"
+)
+
+func isSameLength(s1 string, s2 string) bool { // Function checks length of strings
+
+	if len(s1) == len(s2) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func hasSameLetters(s1 string, s2 string) bool { // Function checks the letters of the strings (Scrambled and Unscrambled Words)
+	var counter int
+	for _, letter1 := range s1 {
+		for _, letter2 := range s2 {
+			if letter1 == letter2 {
+				counter++
+				break
+			}
+		}
+	}
+	if counter == len(s1) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (in *Instance) digEventScramble(msg discord.Message) {
+	scramble := exp.digEventScramble.FindStringSubmatch(msg.Content)[1] // Scrambled word is at index 1 of the search query
+
+	var Unscrambled []string // Unscrambled Solution
+
+	for _, word := range in.Compat.AllowedScrambles { // Allowed Scrambles in Compatibility
+		if isSameLength(scramble, word) && hasSameLetters(scramble, word) {
+			Unscrambled = append(Unscrambled, word)
+			in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+				Value: Unscrambled[0], // Note to self: Type error - Value is string and Unscrambled is []String
+				Log:   "responding to dig scramble",
+			})
+			return
+		}
+	}
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
+		Log:   "no allowed dig options provided, responding",
+	})
+}
+
+func (in *Instance) digEnd(msg discord.Message) {
+	trigger := in.sdlr.AwaitResumeTrigger()
+	if trigger == nil {
+		return
+	}
+	if msg.ReferencedMessage.Content != digCmdValue {
+		return
+	}
+	if trigger.Value == digCmdValue &&
+		!exp.digEventScramble.MatchString(msg.Content) {
+		in.sdlr.Resume()
+	}
+}

--- a/instance/dig.go
+++ b/instance/dig.go
@@ -70,6 +70,7 @@ func (in *Instance) digEventScramble(msg discord.Message) {
 	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
 		Value: in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
 		Log:   "no allowed dig options provided, responding",
+		Amount: 3,
 	})
 }
 

--- a/instance/dig.go
+++ b/instance/dig.go
@@ -10,6 +10,7 @@ package instance
 
 import (
 	"math/rand"
+	"regexp"
 
 	"github.com/dankgrinder/dankgrinder/discord"
 	"github.com/dankgrinder/dankgrinder/instance/scheduler"
@@ -41,7 +42,20 @@ func hasSameLetters(s1 string, s2 string) bool { // Function checks the letters 
 	}
 }
 
-func (in *Instance) digEventScramble(msg discord.Message) {
+func find(tt string, stuff []string) (string, string) { //Some amazing stolen/borrowed code which finds the missing word and phrase from a list of pre-determined phrases
+	re := regexp.MustCompile("_")
+	q := re.ReplaceAllString(tt, `(\w+)`)
+	re2 := regexp.MustCompile(q)
+	for _, s := range stuff {
+		found := re2.FindStringSubmatch(s)
+		if len(found) > 0 {
+			return s, found[1]
+		}
+	}
+	return "", ""
+}
+
+func (in *Instance) digEventScramble(msg discord.Message) { // Dig Event Unscramble
 	scramble := exp.digEventScramble.FindStringSubmatch(msg.Content)[1] // Scrambled word is at index 1 of the search query
 
 	var Unscrambled []string // Unscrambled Solution
@@ -50,7 +64,7 @@ func (in *Instance) digEventScramble(msg discord.Message) {
 		if isSameLength(scramble, word) && hasSameLetters(scramble, word) {
 			Unscrambled = append(Unscrambled, word)
 			in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-				Value: Unscrambled[0], // Note to self: Type error - Value is string and Unscrambled is []String
+				Value: Unscrambled[0],
 				Log:   "responding to dig scramble",
 			})
 			return
@@ -62,7 +76,7 @@ func (in *Instance) digEventScramble(msg discord.Message) {
 	})
 }
 
-func (in *Instance) digEventRetype(msg discord.Message) {
+func (in *Instance) digEventRetype(msg discord.Message) { // Dig Event Retype Stolen from Grind95
 	res := exp.digEventRetype.FindStringSubmatch(msg.Content)[1]
 	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
 		Value: clean(res),
@@ -70,7 +84,22 @@ func (in *Instance) digEventRetype(msg discord.Message) {
 	})
 }
 
-func (in *Instance) digEnd(msg discord.Message) {
+func (in *Instance) digEventFTB(msg discord.Message) { // Dig event Fill in the blank
+	filltheblank := exp.digEventFTB.FindStringSubmatch(msg.Content)[1]
+	ree := regexp.MustCompile(`[a-z]{1}( _)+`)
+	var pruned string = ree.ReplaceAllString(filltheblank, `_`) //Regex tested, is correct.
+	_, s := find(pruned, in.Compat.AllowedFTB)
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: s,
+		Log:   "responding to Dig retype event",
+	})
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
+		Log:   "no allowed fill in the blanks, cancelling",
+	})
+}
+
+func (in *Instance) digEnd(msg discord.Message) { // Scheduling
 	trigger := in.sdlr.AwaitResumeTrigger()
 	if trigger == nil {
 		return
@@ -84,6 +113,10 @@ func (in *Instance) digEnd(msg discord.Message) {
 	}
 	if trigger.Value == digCmdValue &&
 		!exp.digEventRetype.MatchString(msg.Content) {
+		in.sdlr.Resume()
+	}
+	if trigger.Value == digCmdValue &&
+		!exp.digEventFTB.MatchString(msg.Content) {
 		in.sdlr.Resume()
 	}
 }

--- a/instance/dig.go
+++ b/instance/dig.go
@@ -87,13 +87,18 @@ func (in *Instance) digEventFTB(msg discord.Message) {
 	// Replacing the missing word and the hint with an underscore for compatibility with find function
 	var pruned string = ree.ReplaceAllString(fillTheBlank, `_`)
 	_, s := find(pruned, in.Compat.AllowedFTB)
+	if len(s) > 0 {
+		in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+			Value: s,
+			Log:   "responding to Dig retype event",
+		})
+		return
+	}
+
 	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: s,
-		Log:   "responding to Dig retype event",
-	})
-	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
-		Log:   "no allowed fill in the blanks, cancelling",
+		Value:  in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
+		Log:    "no allowed fill in the blanks, cancelling",
+		Amount: 3,
 	})
 }
 

--- a/instance/dig.go
+++ b/instance/dig.go
@@ -62,6 +62,14 @@ func (in *Instance) digEventScramble(msg discord.Message) {
 	})
 }
 
+func (in *Instance) digEventRetype(msg discord.Message) {
+	res := exp.digEventRetype.FindStringSubmatch(msg.Content)[1]
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: clean(res),
+		Log:   "responding to Dig retype event",
+	})
+}
+
 func (in *Instance) digEnd(msg discord.Message) {
 	trigger := in.sdlr.AwaitResumeTrigger()
 	if trigger == nil {
@@ -72,6 +80,10 @@ func (in *Instance) digEnd(msg discord.Message) {
 	}
 	if trigger.Value == digCmdValue &&
 		!exp.digEventScramble.MatchString(msg.Content) {
+		in.sdlr.Resume()
+	}
+	if trigger.Value == digCmdValue &&
+		!exp.digEventRetype.MatchString(msg.Content) {
 		in.sdlr.Resume()
 	}
 }

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -46,6 +46,7 @@ type Instance struct {
 	lastBalanceUpdate time.Time
 	fatal             chan error
 	isClosed          bool
+	result            map[string]string
 }
 
 func (in *Instance) Start() error {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -47,6 +47,7 @@ type Instance struct {
 	fatal             chan error
 	isClosed          bool
 	result            map[string]string
+	result2           string
 }
 
 func (in *Instance) Start() error {

--- a/instance/router.go
+++ b/instance/router.go
@@ -33,7 +33,7 @@ var exp = struct {
 	shop:             regexp.MustCompile(`pls shop ([a-zA-Z\s]+)`),
 	blackjack:        regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
 	blackjackBal:     regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
-	digEventScramble: regexp.MustCompile(`15\sseconds\s\x60(.+)\x60`),
+	digEventScramble: regexp.MustCompile(`Quickly unscramble the word to uncover what's in the dirt! in the next 15\sseconds\s\x60(.+)\x60`),
 }
 
 var numFmt = message.NewPrinter(language.English)

--- a/instance/router.go
+++ b/instance/router.go
@@ -21,17 +21,19 @@ var exp = struct {
 	shop,
 	blackjack,
 	blackjackBal,
+	digEventScramble,
 	event *regexp.Regexp
 }{
-	search:       regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
-	fhEvent:      regexp.MustCompile(`10\sseconds.*\s?([Tt]yping|[Tt]ype)\s\x60(.+)\x60`),
-	hl:           regexp.MustCompile(`Your hint is \*\*([0-9]+)\*\*`),
-	bal:          regexp.MustCompile(`\*\*Wallet\*\*: \x60?⏣?\s?([0-9,]+)\x60?`),
-	event:        regexp.MustCompile(`^(Attack the boss by typing|Type) \x60(.+)\x60`),
-	gift:         regexp.MustCompile(`[a-zA-Z\s]* \(([0-9,]+) owned\)`),
-	shop:         regexp.MustCompile(`pls shop ([a-zA-Z\s]+)`),
-	blackjack:    regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
-	blackjackBal: regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
+	search:           regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
+	fhEvent:          regexp.MustCompile(`10\sseconds.*\s?([Tt]yping|[Tt]ype)\s\x60(.+)\x60`),
+	hl:               regexp.MustCompile(`Your hint is \*\*([0-9]+)\*\*`),
+	bal:              regexp.MustCompile(`\*\*Wallet\*\*: \x60?⏣?\s?([0-9,]+)\x60?`),
+	event:            regexp.MustCompile(`^(Attack the boss by typing|Type) \x60(.+)\x60`),
+	gift:             regexp.MustCompile(`[a-zA-Z\s]* \(([0-9,]+) owned\)`),
+	shop:             regexp.MustCompile(`pls shop ([a-zA-Z\s]+)`),
+	blackjack:        regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
+	blackjackBal:     regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
+	digEventScramble: regexp.MustCompile(`15\sseconds\s\x60(.+)\x60`),
 }
 
 var numFmt = message.NewPrinter(language.English)
@@ -106,6 +108,21 @@ func (in *Instance) router() *discord.MessageRouter {
 		Author(DMID).
 		RespondsTo(in.Client.User.ID).
 		Handler(in.fhEnd)
+
+	//Digging Without Event
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.digEnd)
+	//Digging With Scramble
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.digEventScramble).
+		Mentions(in.Client.User.ID).
+		Handler(in.digEventScramble)
+	//Digging with other minigames here
 
 	// Postmeme.
 	rtr.NewRoute().

--- a/instance/router.go
+++ b/instance/router.go
@@ -24,20 +24,38 @@ var exp = struct {
 	digEventScramble,
 	digEventRetype,
 	digEventFTB,
+	workEventReverse,
+	workEventRetype,
+	workEventScramble,
+	workEventSoccer,
+	workEventHangman,
+	workEventMemory,
+	workEventColor,
+	workEventMemory2,
+	workEventColor2,
 	event *regexp.Regexp
 }{
-	search:           regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
-	fhEvent:          regexp.MustCompile(`10\sseconds.*\s?([Tt]yping|[Tt]ype)\s\x60(.+)\x60`),
-	hl:               regexp.MustCompile(`Your hint is \*\*([0-9]+)\*\*`),
-	bal:              regexp.MustCompile(`\*\*Wallet\*\*: \x60?⏣?\s?([0-9,]+)\x60?`),
-	event:            regexp.MustCompile(`^(Attack the boss by typing|Type) \x60(.+)\x60`),
-	gift:             regexp.MustCompile(`[a-zA-Z\s]* \(([0-9,]+) owned\)`),
-	shop:             regexp.MustCompile(`pls shop ([a-zA-Z\s]+)`),
-	blackjack:        regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
-	blackjackBal:     regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
-	digEventScramble: regexp.MustCompile(`Quickly unscramble the word to uncover what's in the dirt! in the next 15\sseconds\s\x60(.+)\x60`),
-	digEventRetype:   regexp.MustCompile(`Quickly re-type the phrase to uncover what's in the dirt! in the next 15 seconds\nType\s\x60(.+)\x60`),
-	digEventFTB:      regexp.MustCompile(`Quickly guess the missing word to uncover what's in the dirt in the next 15 seconds!\n\x60(.+)\x60`),
+	search:            regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
+	fhEvent:           regexp.MustCompile(`10\sseconds.*\s?([Tt]yping|[Tt]ype)\s\x60(.+)\x60`),
+	hl:                regexp.MustCompile(`Your hint is \*\*([0-9]+)\*\*`),
+	bal:               regexp.MustCompile(`\*\*Wallet\*\*: \x60?⏣?\s?([0-9,]+)\x60?`),
+	event:             regexp.MustCompile(`^(Attack the boss by typing|Type) \x60(.+)\x60`),
+	gift:              regexp.MustCompile(`[a-zA-Z\s]* \(([0-9,]+) owned\)`),
+	shop:              regexp.MustCompile(`pls shop ([a-zA-Z\s]+)`),
+	blackjack:         regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
+	blackjackBal:      regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
+	digEventScramble:  regexp.MustCompile(`Quickly unscramble the word to uncover what's in the dirt! in the next 15\sseconds\s\x60(.+)\x60`),
+	digEventRetype:    regexp.MustCompile(`Quickly re-type the phrase to uncover what's in the dirt! in the next 15 seconds\nType\s\x60(.+)\x60`),
+	digEventFTB:       regexp.MustCompile(`Quickly guess the missing word to uncover what's in the dirt in the next 15 seconds!\n\x60(.+)\x60`),
+	workEventReverse:  regexp.MustCompile(`\*\*Work for (.+)\*\* - Reverse - Type the following word backwards.\n\x60(.+)\x60`), //Index 2
+	workEventRetype:   regexp.MustCompile(`\*\*Work for (.+)\*\* - Retype - Retype the following phrase below.\nType\s\x60(.+)\x60`),
+	workEventScramble: regexp.MustCompile(`\*\*Work for (.+)\*\* - Scramble - The following word is scrambled, you need to try and unscramble it to reveal the original word.\n\x60(.+)\x60`),
+	workEventSoccer:   regexp.MustCompile(`\*\*Work for (.+)\*\* - Soccer - Hit the ball into a goal where the goalkeeper is not at! To hit the ball, type \*\*\x60left\x60, \x60right\x60 or \x60middle\x60\*\*.\n:goal::goal::goal:\n(\s*):levitate:`),
+	workEventHangman:  regexp.MustCompile(`\*\*Work for (.+)\*\* - Hangman - Find the missing __word__ in the following sentence:\n\x60(.+)\x60`),
+	workEventMemory:   regexp.MustCompile(`\*\*Work for (.+)\*\* - Memory - Memorize the words shown and type them in chat.\n\x60(.+)\n(.+)\n(.+)\n(.+)\x60`), // test
+	workEventColor:    regexp.MustCompile(`\*\*Work for (.+)\*\* - Color Match - Match the color to the selected word.\n<:(.+):[\d]+>\s\x60(.+)\x60\n<:(.+):[\d]+>\s\x60(.+)\x60\n<:(.+):[\d]+>\s\x60(.+)\x60`),
+	workEventMemory2:  regexp.MustCompile(`\*\*Work for (.+)\*\* - Memory - Memorize the words shown and type them in chat.\n\x60(.+)\n(.+)\n(.+)\x60`),
+	workEventColor2:   regexp.MustCompile(`What color was next to the word \x60(.+)\x60\?`),
 }
 
 var numFmt = message.NewPrinter(language.English)
@@ -140,6 +158,94 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentMatchesExp(exp.digEventFTB).
 		Mentions(in.Client.User.ID).
 		Handler(in.digEventFTB)
+	//Working End (added to prevent crash)
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		RespondsTo(in.Client.User.ID).
+		Mentions(in.Client.User.ID).
+		Handler(in.WorkEnd)
+
+	//Working Reversing string
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventReverse).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventReverse)
+	//Working Retyping string
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventRetype).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventRetype)
+	//Working Scramble solve
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventScramble).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventScramble)
+	//Working Soccer
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventSoccer).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventSoccer)
+	//Working Hangman
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventHangman).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventHangman)
+	//Working Memory
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventMemory).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventMemory)
+	//Working Memory 2
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventMemory2).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventMemory2)
+
+	//Working Color
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventColor).
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workEventColor)
+	//Working Color Response
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventColor2).
+		RespondsTo(in.Client.User.ID).
+		EventType(discord.EventNameMessageUpdate).
+		Handler(in.workEventColor2)
+
+	//Working Don't have a job
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentContains("You don't currently have a job to work at").
+		RespondsTo(in.Client.User.ID).
+		Handler(in.WorkEnd)
+	//Working Recently resigned
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentContains("You recently resigned from your old job.").
+		RespondsTo(in.Client.User.ID).
+		Handler(in.WorkEnd)
 
 	// Postmeme.
 	rtr.NewRoute().

--- a/instance/router.go
+++ b/instance/router.go
@@ -23,6 +23,7 @@ var exp = struct {
 	blackjackBal,
 	digEventScramble,
 	digEventRetype,
+	digEventFTB,
 	event *regexp.Regexp
 }{
 	search:           regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
@@ -36,6 +37,7 @@ var exp = struct {
 	blackjackBal:     regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
 	digEventScramble: regexp.MustCompile(`Quickly unscramble the word to uncover what's in the dirt! in the next 15\sseconds\s\x60(.+)\x60`),
 	digEventRetype:   regexp.MustCompile(`Quickly re-type the phrase to uncover what's in the dirt! in the next 15 seconds\nType\s\x60(.+)\x60`),
+	digEventFTB:      regexp.MustCompile(`Quickly guess the missing word to uncover what's in the dirt in the next 15 seconds!\n\x60(.+)\x60`),
 }
 
 var numFmt = message.NewPrinter(language.English)
@@ -132,6 +134,12 @@ func (in *Instance) router() *discord.MessageRouter {
 		Mentions(in.Client.User.ID).
 		Handler(in.digEventRetype)
 	//Digging with Fill in the blanks
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.digEventFTB).
+		Mentions(in.Client.User.ID).
+		Handler(in.digEventFTB)
 
 	// Postmeme.
 	rtr.NewRoute().

--- a/instance/router.go
+++ b/instance/router.go
@@ -32,6 +32,7 @@ var exp = struct {
 	workEventMemory,
 	workEventColor,
 	workEventMemory2,
+	workEventMemory3,
 	workEventColor2,
 	event *regexp.Regexp
 }{
@@ -55,6 +56,7 @@ var exp = struct {
 	workEventMemory:   regexp.MustCompile(`\*\*Work for (.+)\*\* - Memory - Memorize the words shown and type them in chat.\n\x60(.+)\n(.+)\n(.+)\n(.+)\x60`), // test
 	workEventColor:    regexp.MustCompile(`\*\*Work for (.+)\*\* - Color Match - Match the color to the selected word.\n<:(.+):[\d]+>\s\x60(.+)\x60\n<:(.+):[\d]+>\s\x60(.+)\x60\n<:(.+):[\d]+>\s\x60(.+)\x60`),
 	workEventMemory2:  regexp.MustCompile(`\*\*Work for (.+)\*\* - Memory - Memorize the words shown and type them in chat.\n\x60(.+)\n(.+)\n(.+)\x60`),
+	workEventMemory3:  regexp.MustCompile(`Type the words that were displayed before into the chat now!`),
 	workEventColor2:   regexp.MustCompile(`What color was next to the word \x60(.+)\x60\?`),
 }
 
@@ -193,28 +195,37 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentMatchesExp(exp.workEventHangman).
 		RespondsTo(in.Client.User.ID).
 		Handler(in.workEventHangman)
-	//Working Memory
+	//Working Memory + response
 	rtr.NewRoute().
 		Channel(in.ChannelID).
 		Author(DMID).
 		ContentMatchesExp(exp.workEventMemory).
 		RespondsTo(in.Client.User.ID).
 		Handler(in.workEventMemory)
-	//Working Memory 2
+
 	rtr.NewRoute().
 		Channel(in.ChannelID).
 		Author(DMID).
 		ContentMatchesExp(exp.workEventMemory2).
 		RespondsTo(in.Client.User.ID).
-		Handler(in.workEventMemory2)
-	//Working Color
+		Handler(in.workEventMemory)
+
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.workEventMemory3).
+		RespondsTo(in.Client.User.ID).
+		EventType(discord.EventNameMessageUpdate).
+		Handler(in.workEventMemory3)
+
+	//Working Color + response
 	rtr.NewRoute().
 		Channel(in.ChannelID).
 		Author(DMID).
 		ContentMatchesExp(exp.workEventColor).
 		RespondsTo(in.Client.User.ID).
 		Handler(in.workEventColor)
-	//Working Color Response
+
 	rtr.NewRoute().
 		Channel(in.ChannelID).
 		Author(DMID).
@@ -234,6 +245,13 @@ func (in *Instance) router() *discord.MessageRouter {
 		Channel(in.ChannelID).
 		Author(DMID).
 		ContentContains("You recently resigned from your old job.").
+		RespondsTo(in.Client.User.ID).
+		Handler(in.WorkEnd)
+	// Worked Recently
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentContains("You need to wait").
 		RespondsTo(in.Client.User.ID).
 		Handler(in.WorkEnd)
 	//Work promotion

--- a/instance/router.go
+++ b/instance/router.go
@@ -22,6 +22,7 @@ var exp = struct {
 	blackjack,
 	blackjackBal,
 	digEventScramble,
+	digEventRetype,
 	event *regexp.Regexp
 }{
 	search:           regexp.MustCompile(`Pick from the list below and type the name in chat\.\s\x60(.+)\x60,\s\x60(.+)\x60,\s\x60(.+)\x60`),
@@ -34,6 +35,7 @@ var exp = struct {
 	blackjack:        regexp.MustCompile(`\x60[♥♦♠♣] ([0-9]{1,2}|[JQKA])\x60`),
 	blackjackBal:     regexp.MustCompile(`(You now have|You have) (\*\*)?(⏣\s)?(\*\*)?([0-9,]+)(\*\*)?(\sstill)?\.`),
 	digEventScramble: regexp.MustCompile(`Quickly unscramble the word to uncover what's in the dirt! in the next 15\sseconds\s\x60(.+)\x60`),
+	digEventRetype:   regexp.MustCompile(`Quickly re-type the phrase to uncover what's in the dirt! in the next 15 seconds\nType\s\x60(.+)\x60`),
 }
 
 var numFmt = message.NewPrinter(language.English)
@@ -122,7 +124,14 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentMatchesExp(exp.digEventScramble).
 		Mentions(in.Client.User.ID).
 		Handler(in.digEventScramble)
-	//Digging with other minigames here
+	//Digging with Retype
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentMatchesExp(exp.digEventRetype).
+		Mentions(in.Client.User.ID).
+		Handler(in.digEventRetype)
+	//Digging with Fill in the blanks
 
 	// Postmeme.
 	rtr.NewRoute().
@@ -193,6 +202,16 @@ func (in *Instance) router() *discord.MessageRouter {
 			ContentContains("You don't have a hunting rifle").
 			Mentions(in.Client.User.ID).
 			Handler(in.abHuntingRifle)
+	}
+
+	// Auto-buy shovel.
+	if in.Features.AutoBuy.Shovel {
+		rtr.NewRoute().
+			Channel(in.ChannelID).
+			Author(DMID).
+			ContentContains("You don't have a shovel").
+			Mentions(in.Client.User.ID).
+			Handler(in.abShovel)
 	}
 
 	// Auto-gift

--- a/instance/router.go
+++ b/instance/router.go
@@ -158,14 +158,6 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentMatchesExp(exp.digEventFTB).
 		Mentions(in.Client.User.ID).
 		Handler(in.digEventFTB)
-	//Working End (added to prevent crash)
-	rtr.NewRoute().
-		Channel(in.ChannelID).
-		Author(DMID).
-		RespondsTo(in.Client.User.ID).
-		Mentions(in.Client.User.ID).
-		Handler(in.WorkEnd)
-
 	//Working Reversing string
 	rtr.NewRoute().
 		Channel(in.ChannelID).
@@ -215,7 +207,6 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentMatchesExp(exp.workEventMemory2).
 		RespondsTo(in.Client.User.ID).
 		Handler(in.workEventMemory2)
-
 	//Working Color
 	rtr.NewRoute().
 		Channel(in.ChannelID).
@@ -231,7 +222,6 @@ func (in *Instance) router() *discord.MessageRouter {
 		RespondsTo(in.Client.User.ID).
 		EventType(discord.EventNameMessageUpdate).
 		Handler(in.workEventColor2)
-
 	//Working Don't have a job
 	rtr.NewRoute().
 		Channel(in.ChannelID).
@@ -246,6 +236,13 @@ func (in *Instance) router() *discord.MessageRouter {
 		ContentContains("You recently resigned from your old job.").
 		RespondsTo(in.Client.User.ID).
 		Handler(in.WorkEnd)
+	//Work promotion
+	rtr.NewRoute().
+		Channel(in.ChannelID).
+		Author(DMID).
+		ContentContains("You never fail to amaze me").
+		RespondsTo(in.Client.User.ID).
+		Handler(in.workPromotion)
 
 	// Postmeme.
 	rtr.NewRoute().
@@ -268,7 +265,7 @@ func (in *Instance) router() *discord.MessageRouter {
 		Channel(in.ChannelID).
 		Author(DMID).
 		ContentMatchesExp(exp.search).
-		Mentions(in.Client.User.ID).
+		RespondsTo(in.Client.User.ID).
 		Handler(in.search)
 
 	// Highlow.
@@ -304,7 +301,7 @@ func (in *Instance) router() *discord.MessageRouter {
 			Channel(in.ChannelID).
 			Author(DMID).
 			ContentContains("You don't have a fishing pole").
-			Mentions(in.Client.User.ID).
+			RespondsTo(in.Client.User.ID).
 			Handler(in.abFishingPole)
 	}
 
@@ -314,7 +311,7 @@ func (in *Instance) router() *discord.MessageRouter {
 			Channel(in.ChannelID).
 			Author(DMID).
 			ContentContains("You don't have a hunting rifle").
-			Mentions(in.Client.User.ID).
+			RespondsTo(in.Client.User.ID).
 			Handler(in.abHuntingRifle)
 	}
 
@@ -324,7 +321,7 @@ func (in *Instance) router() *discord.MessageRouter {
 			Channel(in.ChannelID).
 			Author(DMID).
 			ContentContains("You don't have a shovel").
-			Mentions(in.Client.User.ID).
+			RespondsTo(in.Client.User.ID).
 			Handler(in.abShovel)
 	}
 

--- a/instance/work.go
+++ b/instance/work.go
@@ -62,8 +62,9 @@ func (in *Instance) workEventScramble(msg discord.Message) {
 		}
 	}
 	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: in.Compat.WorkCancel[rand.Intn(len(in.Compat.WorkCancel))],
-		Log:   "no allowed work options provided, responding",
+		Value:  in.Compat.WorkCancel[rand.Intn(len(in.Compat.WorkCancel))],
+		Log:    "no allowed work options provided, responding",
+		Amount: 3,
 	})
 }
 
@@ -88,7 +89,7 @@ func (in *Instance) workEventSoccer(msg discord.Message) {
 	}
 }
 
-// Work Event #5 -> Hangman (Copy of fill in the blank!)
+// Work Event #5 -> Hangman
 func (in *Instance) workEventHangman(msg discord.Message) {
 	hangman := exp.workEventHangman.FindStringSubmatch(msg.Content)[2]
 	ree := regexp.MustCompile(`[a-z]{1}( _)+`)
@@ -102,29 +103,34 @@ func (in *Instance) workEventHangman(msg discord.Message) {
 		return
 	}
 	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: in.Compat.WorkCancel[rand.Intn(len(in.Compat.WorkCancel))],
-		Log:   "no allowed hangman, cancelling",
+		Value:  in.Compat.WorkCancel[rand.Intn(len(in.Compat.WorkCancel))],
+		Log:    "no allowed hangman, cancelling",
+		Amount: 3,
 	})
 }
 
-// Work Event #6 -> Memory (4 word)
+// Work Event #6 -> Memory
 func (in *Instance) workEventMemory(msg discord.Message) {
 	words := exp.workEventMemory.FindStringSubmatch(msg.Content)[2:]
-	result := strings.Join(words, " ")
-	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: result,
-		Log:   "responding to Work Memory",
-	})
+	in.result2 = strings.Join(words, " ")
+}
+func (in *Instance) workEventMemory2(msg discord.Message) {
+	words := exp.workEventMemory2.FindStringSubmatch(msg.Content)[2:]
+	in.result2 = strings.Join(words, " ")
 }
 
-// Work Event #6 -> Memory 2 (3 word)
-func (in *Instance) workEventMemory2(msg discord.Message) {
-	words := exp.workEventMemory.FindStringSubmatch(msg.Content)[2:]
-	result := strings.Join(words, " ")
-	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
-		Value: result,
-		Log:   "responding to Work Memory",
-	})
+// Work Event #6 -> Memory Response
+// Memory response does not have any necessary informaton
+// required for functioning of memory event but if the event
+// is responded to before receiving the response, it results
+// in Dank Memer triggering copy paste detection for being too fast
+func (in *Instance) workEventMemory3(msg discord.Message) {
+	if len(in.result2) > 0 {
+		in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+			Value: in.result2,
+			Log:   "responding to Work Memory",
+		})
+	}
 }
 
 // Work Event #7 -> Color

--- a/instance/work.go
+++ b/instance/work.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2021 The Dank Grinder authors.
+//
+// This source code has been released under the GNU Affero General Public
+// License v3.0. A copy of this license is available at
+// https://www.gnu.org/licenses/agpl-3.0.en.html
+//
+// Work Functionality added by https://github.com/V4NSH4J
+
+package instance
+
+import (
+	"math/rand"
+	"regexp"
+	"strings"
+
+	"github.com/dankgrinder/dankgrinder/discord"
+	"github.com/dankgrinder/dankgrinder/instance/scheduler"
+)
+
+// Reverse function (Reverses any string)
+func Reverse(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+// Work Event #1 -> Reversing the String
+func (in *Instance) workEventReverse(msg discord.Message) {
+	frontward := exp.workEventReverse.FindStringSubmatch(msg.Content)[2]
+
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: Reverse(frontward),
+		Log:   "responding to working event reverse",
+	})
+}
+
+// Work Event #2 -> Retyping
+func (in *Instance) workEventRetype(msg discord.Message) {
+	res := exp.workEventRetype.FindStringSubmatch(msg.Content)[2]
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: clean(res),
+		Log:   "responding to work retype",
+	})
+}
+
+// Work Event #3 -> Scramble Solve
+func (in *Instance) workEventScramble(msg discord.Message) {
+	scramble := exp.workEventScramble.FindStringSubmatch(msg.Content)[2]
+
+	var Unscrambled []string
+
+	for _, word := range in.Compat.AllowedScramblesWork {
+		if len(scramble) == len(word) && haveSameChars(scramble, word) {
+			Unscrambled = append(Unscrambled, word)
+			in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+				Value: Unscrambled[0],
+				Log:   "responding to work scramble",
+			})
+			return
+		}
+	}
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: in.Compat.WorkCancel[rand.Intn(len(in.Compat.WorkCancel))],
+		Log:   "no allowed work options provided, responding",
+	})
+}
+
+// Work Event #4 -> Soccer
+func (in *Instance) workEventSoccer(msg discord.Message) {
+	spaces := exp.workEventSoccer.FindStringSubmatch(msg.Content)[2]
+	var q int = len(spaces) // q is a position of the goal keeper of sorts.
+
+	if q <= 6 {
+		in.sdlr.ResumeWithCommand(&scheduler.Command{
+			Value: "right",
+			Log:   "responding to work soccer",
+		})
+	}
+	if q > 6 {
+		in.sdlr.ResumeWithCommand(&scheduler.Command{
+			Value: "left",
+			Log:   "responding to work soccer",
+		})
+	}
+}
+
+// Work Event #5 -> Hangman (Copy of fill in the blank!)
+func (in *Instance) workEventHangman(msg discord.Message) {
+	hangman := exp.workEventHangman.FindStringSubmatch(msg.Content)[2]
+	ree := regexp.MustCompile(`[a-z]{1}( _)+`)
+	var pruned string = ree.ReplaceAllString(hangman, `_`) //Regex tested, is correct.
+	_, s := find(pruned, in.Compat.AllowedHangman)
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: s,
+		Log:   "responding to Work Hangman",
+	})
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{ //Pretty sure this doesn't work as intended.
+		Value: in.Compat.DigCancel[rand.Intn(len(in.Compat.DigCancel))],
+		Log:   "no allowed hangman, cancelling",
+	})
+}
+
+// Work Event #6 -> Memory
+func (in *Instance) workEventMemory(msg discord.Message) {
+	words := exp.workEventMemory.FindStringSubmatch(msg.Content)[2:]
+	result := strings.Join(words, " ")
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: result,
+		Log:   "responding to Work Memory",
+	})
+}
+
+// Work Event #6 -> Memory 2
+func (in *Instance) workEventMemory2(msg discord.Message) {
+	words := exp.workEventMemory.FindStringSubmatch(msg.Content)[2:]
+	result := strings.Join(words, " ")
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: result,
+		Log:   "responding to Work Memory",
+	})
+}
+
+// Work Event #7 -> Color (Fix me!)
+func (in *Instance) workEventColor(msg discord.Message) {
+	colorObject := exp.workEventColor.FindStringSubmatch(msg.Content)[2:]
+	in.result = map[string]string{colorObject[1]: colorObject[0], colorObject[3]: colorObject[2], colorObject[5]: colorObject[4]}
+
+}
+
+// Work Event #7 -> Color response
+func (in *Instance) workEventColor2(msg discord.Message) {
+	itemcolor := exp.workEventColor2.FindStringSubmatch(msg.Content)[1]
+	var res = in.result[itemcolor]
+	in.sdlr.ResumeWithCommandOrPrioritySchedule(&scheduler.Command{
+		Value: res,
+		Log:   "responding to Work Color",
+	})
+}
+
+func (in *Instance) WorkEnd(msg discord.Message) {
+	trigger := in.sdlr.AwaitResumeTrigger()
+	if trigger == nil || trigger.Value != workCmdValue {
+		return
+	}
+	if exp.workEventScramble.MatchString(msg.Content) ||
+		exp.workEventRetype.MatchString(msg.Content) ||
+		exp.workEventHangman.MatchString(msg.Content) ||
+		exp.workEventMemory.MatchString(msg.Content) ||
+		exp.workEventMemory2.MatchString(msg.Content) ||
+		exp.workEventReverse.MatchString(msg.Content) ||
+		exp.workEventColor.MatchString(msg.Content) ||
+		exp.workEventColor2.MatchString(msg.Content) ||
+		exp.workEventSoccer.MatchString(msg.Content) {
+		return
+	}
+	in.sdlr.Resume()
+}


### PR DESCRIPTION
[Link to feature approval](https://github.com/dankgrinder/dankgrinder/issues/63)
Successfully added the much awaited "pls work" function along with 7 event types: 
**Work Event 1 - Scramble**
![unscramble](https://user-images.githubusercontent.com/79518089/120333841-b8f53180-c30d-11eb-9007-cb8bb35e9f81.png)
-> Added scramble solve functionality. The unscrambled words are configurable in the config to accommodate a variety of professions and future updates. 
**Work Event 2 - Backward typing** 
![backward](https://user-images.githubusercontent.com/79518089/120334022-e5a94900-c30d-11eb-9547-99ad632b1ebd.png)
-> Added Backward typing functionality. This is common across all professions. Finds the string from the discord message and reverses it
**Work Event 3 - Color**
![colo](https://user-images.githubusercontent.com/79518089/120334201-14bfba80-c30e-11eb-82e0-d55521516076.png)
-> Common for all professions. From a given list of  associated colors and items, grinder responds with the associated color for the item in question. Thank you grind95 for helping me make this
**Work Event 4 - Memory**
![memory](https://user-images.githubusercontent.com/79518089/120334532-551f3880-c30e-11eb-9a17-45aadff7345d.png)
-> Common for all professions. When given a list of 3-4 words and asked to respond upon message edit. Grinder converts the word into a string and responds.
-> I could not find one single regex for a list of 3 words and the one with 4. So I compiled their regex separately and added them as separate methods. I made an attempt to have the same function for both of them which resulted in panic due to slices being out of range. But atleast it functions well. now. (Let me know if you want me to change it, I can look more into it)
![error](https://user-images.githubusercontent.com/79518089/120336115-ab40ab80-c30f-11eb-9224-2f835cef25c1.png)

-> Added the result in the instance struct. and made it so grinder only responds when the initial message is edited. If grinder responds without the initial message being edited, Dank Memer assumes the user copy pasted the list and fails the work event. 
**Work Event 5 - Retype**
![retype](https://user-images.githubusercontent.com/79518089/120335307-ff975b80-c30e-11eb-8089-4a07900c6c14.png)
-> Common for all professions. Same old code just retypes the string. 
**Work Event 6 - Hangman**
![hangman](https://user-images.githubusercontent.com/79518089/120335459-1ccc2a00-c30f-11eb-91d9-7b3696d4c308.png)
-> Added hangman solving ability. The complete phrases are configurable in the config file to accomodate all professions and updates. 
**Work Event 7 - Soccer**
![soccer](https://user-images.githubusercontent.com/79518089/120335653-45542400-c30f-11eb-96d4-001897d09c07.png)
-> Common for all professions. Grinder notes the position of the goal keeper using regex and responds accordingly to the conditions. 
-> This event usually has an editing message where the goal keeper changes position thrice before failing the work event. The changing positions would be hard to configure so soccer is solved for the first position itself. Completely functional. 

Apart from the work event. This was built upon my previous [dankgrinder with dig](https://github.com/dankgrinder/dankgrinder/pull/61) but is almost independent of it. Just calls a couple functions from dig.go.
Also changed a couple lines (Mentions -> RespondsTo) in router.go to fix shovel, rifle and pole autobuy and search. 

Side notes: 
->Added "pls work mod" into custom commands by default because before work can function, the instances require a profession (Can be omitted) 
->By default the config has keywords and phrases for the discord moderator profession. For scraping the keywords for other professions, head on to any server and search "work for (profession you want)" and scroll a bit till you collect all keywords. 
-> Different professions for accounts. This is limited by custom commands if any. Make different clusters/ accounts do different command for job and add the keywords and phrases for all the professions of your accounts and it should work fabulously. 
-> I added 2 fields "result" and "result2" in the instance struct as I was unsure if one would do the job as I needed one to be a string while the other to be a map. One helps in Memory event and the other in color event as both events involve detection of edited message and responding. 
-> Getting messages related to promotions, firing and working recently ends the word command for now. 
-> Different jobs require different number of daily hours, set the work cooldown in compatibility accordingly. 

I want this to work perfectly, if anyone finds any bugs feel free to DM me on discord CampingRunner#4408 
Grind95 I'm awaiting your review :) 




